### PR TITLE
E2E TCP testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+This is a TCP chat-room client.
+
+To launch, run index.js

--- a/chatRoom.js
+++ b/chatRoom.js
@@ -42,8 +42,6 @@ module.exports = class ChatRoom {
     this.clients.forEach(c => {
       c.write(`${oldNick} has changed their name to ${client.nick}` + '\n');
     });
-   
-    
   }
 
   changeNickRandom(client, message) {
@@ -52,8 +50,6 @@ module.exports = class ChatRoom {
     this.clients.forEach(c => {
       c.write(`${oldNick} has changed their name to ${client.nick}` + '\n');
     });
-    
   }
-    
-
+  
 };

--- a/chatRoom.js
+++ b/chatRoom.js
@@ -14,8 +14,8 @@ module.exports = class ChatRoom {
   add(client) {
     client.nick = this.nick();
     this.clients.push(client);
+    client.write('Use these commands:\n/newName <name> will change name to one of your choosing \n/newRandom will generate a random name\n');
     this.clients.forEach(c => {
-      client.write('Use these commands:\n/newName <name> will change name to one of your choosing \n/newRandom will generate a random name\n');
       c.write(`${client.nick} has connected` + '\n');
     });
     console.log(`${client.nick} has connected`);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+const server = require('./tcpChat');
+const port = process.env.PORT || 65000;
+
+server.listen(port, err => {
+  if (err) console.log('error!', err);
+  else console.log('server listening on port', server.address().port);
+});

--- a/tcpChat.js
+++ b/tcpChat.js
@@ -2,7 +2,7 @@ const net = require('net');
 const ChatRoom = require('./chatRoom');
 const chatRoom = new ChatRoom();
 
-const server = net.createServer(client => {
+module.exports = net.createServer(client => {
   client.setEncoding('utf-8');
 
   chatRoom.add(client);
@@ -23,8 +23,9 @@ const server = net.createServer(client => {
 
 });
 
-const port = 65000;
-server.listen(port, err => {
-  if (err) console.log('error!', err);
-  else console.log('server listening on port', port);
-});
+// const port = 65000;
+// server.listen(port, err => {
+//   if (err) console.log('error!', err);
+//   else console.log('server listening on port', port);
+// });
+

--- a/tcpChat.js
+++ b/tcpChat.js
@@ -23,10 +23,4 @@ const server = net.createServer(client => {
 
 });
 
-// const port = 65000;
-// server.listen(port, err => {
-//   if (err) console.log('error!', err);
-//   else console.log('server listening on port', port);
-// });
-
 module.exports = server;

--- a/tcpChat.js
+++ b/tcpChat.js
@@ -2,7 +2,7 @@ const net = require('net');
 const ChatRoom = require('./chatRoom');
 const chatRoom = new ChatRoom();
 
-module.exports = net.createServer(client => {
+const server = net.createServer(client => {
   client.setEncoding('utf-8');
 
   chatRoom.add(client);
@@ -29,3 +29,4 @@ module.exports = net.createServer(client => {
 //   else console.log('server listening on port', port);
 // });
 
+module.exports = server;

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -47,12 +47,14 @@ describe('E2E test for a tcp chat client', () => {
     client2.on('data', data => {
       if (data.substring(data.length - 10) === message) {
         assert.equal(data.substring(data.length - 10), message);
+        console.log(data.substring(data.length - 10));
         done();
       }
     });
     client1.on('data', data => {
       if (data.substring(data.length - 10) === message) {
         assert.isNotOk(data);
+        done();
       }
     });
     client1.write(message);

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -60,6 +60,12 @@ describe('E2E test for a tcp chat client', () => {
     client1.write(message);
   });
 
+  after(done => {
+    client1.end();
+    client2.end();
+    server.close(done);
+  });
+
 });
 
 

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -25,6 +25,17 @@ describe('E2E test for a tcp chat client', () => {
     });
   });
 
+  before(done => {
+    client3 = net.connect({port: port}, err => {
+      if (err) done(err);
+      else {
+        client3.setEncoding('utf8');
+        done();
+      }
+    });
+  });
+
+
 
   it('Should display instruction to new client', (done) => {
     client1.once('data', data => {
@@ -56,16 +67,10 @@ describe('E2E test for a tcp chat client', () => {
   //   done();
   // });
 
-    client3 = net.connect({port: port}), err => {
-      if (err) done(err);
-      else {
-        client3.setEncoding('utf8');
 
-      }
-    };
    
     client2.on('data', data => {
-      if (data.split(' ')[0] !== 'Use' && data.substring(data.length -9) !== 'connected') {
+      if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
         console.log('client2 data', data);
         assert.equal(data.substring(data.length - 10), 'hello guys');
         
@@ -73,9 +78,9 @@ describe('E2E test for a tcp chat client', () => {
       }
     });
     client3.on('data', data => {
-      if (data.split(' ')[0] !== 'Use' && data.substring(data.length -9) !== 'connected') {
+      if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
         console.log('client3 data', data);
-        assert.equal(data.substring(data.length - 10), 'hello guys');
+        assert.equal(data.substring(data.length - 10), 'hello');
         done();
       }
     });

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -1,36 +1,75 @@
 const assert = require('chai').assert;
 const ChatRoom = require('../chatRoom');
+const server = require('../tcpChat');
+const net = require('net');
 
-describe('A tcp chat client that tracks new connections, broadcasts messages, and allows name changes', () => {
+describe('E2E test for a tcp chat client', () => {
+  const port = 65000;
+  let client1 = null;
+  let client2 = null;
 
-  const chatRoom = new ChatRoom();
 
-  class MockClient {
-    write(message) {
-      this.received = message;
-    }
-  }
-  const client1 = new MockClient();
-  const client2 = new MockClient();
-
-  it('should add clients', () => {
-    assert.equal(chatRoom.clients.length, 0);
-    chatRoom.add(client1);
-    assert.equal(chatRoom.clients.length, 1);
-    assert.equal(chatRoom.clients[0], client1);
+  before(done => {
+    server.listen(port, done);
   });
 
-  it('should broadcast messages to other clients', () => {
-    chatRoom.add(client2);
-    chatRoom.send(client2, 'hello people');
-    assert.equal(client1.received.substring(client1.received.indexOf(': ') + 2), 'hello people');
-  });
-
-  it('should accept a new name from input', () => {
-    chatRoom.changeNick(client1, '/newName Roger the clown');
-    assert.equal(client1.nick, 'Roger the clown');
+  before(done => {
+    client1 = net.connect({port: port}, err => {
+      if (err) done(err);
+      else {
+        client1.setEncoding('utf8');
+        done();
+      }
+    });
   });
 
 
+  it('Should display instruction to new client', (done) => {
+    client1.once('data', data => {
+      assert.equal(data.split('name\n')[0] + 'name\n', 'Use these commands:\n/newName <name> will change name to one of your choosing \n/newRandom will generate a random name\n');
+      done();
+    });
+    // client2.once('data', data => {
+    //   assert.equal(data.substring(data.indexOf(': ') + 2, 'has connected'));
+    // });
+    // makeClient(client2);
+  });
 
 });
+
+
+
+
+// describe('Unit testing for a tcp chat client that tracks new connections, broadcasts messages, and allows name changes', () => {
+
+//   const chatRoom = new ChatRoom();
+
+//   class MockClient {
+//     write(message) {
+//       this.received = message;
+//     }
+//   }
+//   const client1 = new MockClient();
+//   const client2 = new MockClient();
+
+//   it('should add clients', () => {
+//     assert.equal(chatRoom.clients.length, 0);
+//     chatRoom.add(client1);
+//     assert.equal(chatRoom.clients.length, 1);
+//     assert.equal(chatRoom.clients[0], client1);
+//   });
+
+//   it('should broadcast messages to other clients', () => {
+//     chatRoom.add(client2);
+//     chatRoom.send(client2, 'hello people');
+//     assert.equal(client1.received.substring(client1.received.indexOf(': ') + 2), 'hello people');
+//   });
+
+//   it('should accept a new name from input', () => {
+//     chatRoom.changeNick(client1, '/newName Roger the clown');
+//     assert.equal(client1.nick, 'Roger the clown');
+//   });
+
+
+
+// });

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -44,16 +44,16 @@ describe('E2E test for a tcp chat client', () => {
   });
 
   it('Should display messages from one client to the others', done => {
-    client2.on('data', data => {
-      if (data.substring(data.length - 10) === message) {
-        assert.equal(data.substring(data.length - 10), message);
-        console.log(data.substring(data.length - 10));
-        done();
-      }
-    });
     client1.on('data', data => {
       if (data.substring(data.length - 10) === message) {
         assert.isNotOk(data);
+        done();
+      }
+    });
+    client2.on('data', data => {
+      if (data.substring(data.length - 10) === message) {
+        assert.equal(data.substring(data.length - 10), message);
+        console.log('client2 gets', data.substring(data.length - 10));
         done();
       }
     });

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -3,13 +3,11 @@ const ChatRoom = require('../chatRoom');
 const server = require('../tcpChat');
 const net = require('net');
 
-
 describe('E2E test for a tcp chat client', () => {
   const port = 65000;
   let client1 = null;
   let client2 = null;
-  let client3 = null;
-
+  let message = 'heyyy guys';
 
   before(done => {
     server.listen(port, done);
@@ -25,26 +23,14 @@ describe('E2E test for a tcp chat client', () => {
     });
   });
 
-  // before(done => {
-  //   client3 = net.connect({port: port}, err => {
-  //     if (err) done(err);
-  //     else {
-  //       client3.setEncoding('utf8');
-  //       done();
-  //     }
-  //   });
-  // });
-
-
-
-  it('Should display instruction to new client', (done) => {
+  it('Should display instruction to new client', done => {
     client1.once('data', data => {
       assert.equal(data.split('name\n')[0] + 'name\n', 'Use these commands:\n/newName <name> will change name to one of your choosing \n/newRandom will generate a random name\n');
       done();
     });
   });
 
-  it('Should display <client> has connected to all clients', (done) => {
+  it('Should display <client> has connected to all clients', done => {
     client1.once('data', data => {
       assert.equal(data.substring(data.indexOf(' ') + 1), 'has connected\n');
       done();
@@ -57,75 +43,54 @@ describe('E2E test for a tcp chat client', () => {
     });
   });
 
-  // it('Should display messages from one client to the others', done => {
+  it('Should display messages from one client to the others', done => {
+    client2.on('data', data => {
+      if (data.substring(data.length - 10) === message) {
+        assert.equal(data.substring(data.length - 10), message);
+        done();
+      }
+    });
+    client1.on('data', data => {
+      if (data.substring(data.length - 10) === message) {
+        assert.isNotOk(data);
+      }
+    });
+    client1.write(message);
+  });
 
-  //   client2.on('data', data => {
-  //     if (data.substring(data.length - 11) !== 'connected\n') {
-  //       console.log(data);
-  //       assert.equal(data.substring(data.length - 10), 'helys');
-  //       done();
-  //     }
-  //   });
-  //   client1.write('hello guys');
-  // });
+});
 
 
-   
-//     client2.on('data', data => {
-//       if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
-//         console.log('client2 data', data);
-//         assert.equal(data.substring(data.length - 10), 'hello guys');
-        
+// describe('Unit testing for a tcp chat client that tracks new connections, broadcasts messages, and allows name changes', () => {
 
-//       }
-//     });
-//     client3.on('data', data => {
-//       if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
-//         console.log('client3 data', data);
-//         assert.equal(data.substring(data.length - 10), 'hello');
-//         done();
-//       }
-//     });
-//     client1.on('data', data => {
-//       assert.equal(data.substring(data.indexOf(' ') + 1), 'has connected\n');
-//     });
-//     client1.write('hello guys');
+//   const chatRoom = new ChatRoom();
+
+//   class MockClient {
+//     write(message) {
+//       this.received = message;
+//     }
+//   }
+//   const client1 = new MockClient();
+//   const client2 = new MockClient();
+
+//   it('should add clients', () => {
+//     assert.equal(chatRoom.clients.length, 0);
+//     chatRoom.add(client1);
+//     assert.equal(chatRoom.clients.length, 1);
+//     assert.equal(chatRoom.clients[0], client1);
 //   });
+
+//   it('should broadcast messages to other clients', () => {
+//     chatRoom.add(client2);
+//     chatRoom.send(client2, 'hello people');
+//     assert.equal(client1.received.substring(client1.received.indexOf(': ') + 2), 'hello people');
+//   });
+
+//   it('should accept a new name from input', () => {
+//     chatRoom.changeNick(client1, '/newName Roger the clown');
+//     assert.equal(client1.nick, 'Roger the clown');
+//   });
+
+
+
 // });
-
-});
-
-
-describe('Unit testing for a tcp chat client that tracks new connections, broadcasts messages, and allows name changes', () => {
-
-  const chatRoom = new ChatRoom();
-
-  class MockClient {
-    write(message) {
-      this.received = message;
-    }
-  }
-  const client1 = new MockClient();
-  const client2 = new MockClient();
-
-  it('should add clients', () => {
-    assert.equal(chatRoom.clients.length, 0);
-    chatRoom.add(client1);
-    assert.equal(chatRoom.clients.length, 1);
-    assert.equal(chatRoom.clients[0], client1);
-  });
-
-  it('should broadcast messages to other clients', () => {
-    chatRoom.add(client2);
-    chatRoom.send(client2, 'hello people');
-    assert.equal(client1.received.substring(client1.received.indexOf(': ') + 2), 'hello people');
-  });
-
-  it('should accept a new name from input', () => {
-    chatRoom.changeNick(client1, '/newName Roger the clown');
-    assert.equal(client1.nick, 'Roger the clown');
-  });
-
-
-
-});

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -25,15 +25,15 @@ describe('E2E test for a tcp chat client', () => {
     });
   });
 
-  before(done => {
-    client3 = net.connect({port: port}, err => {
-      if (err) done(err);
-      else {
-        client3.setEncoding('utf8');
-        done();
-      }
-    });
-  });
+  // before(done => {
+  //   client3 = net.connect({port: port}, err => {
+  //     if (err) done(err);
+  //     else {
+  //       client3.setEncoding('utf8');
+  //       done();
+  //     }
+  //   });
+  // });
 
 
 
@@ -55,75 +55,77 @@ describe('E2E test for a tcp chat client', () => {
         client2.setEncoding('utf8');
       }
     });
-
   });
 
-  it('Should display messages from one client to the others', done => {
-  //   client1.write('hello guys');
+  // it('Should display messages from one client to the others', done => {
 
   //   client2.on('data', data => {
-  //     console.log(data);
+  //     if (data.substring(data.length - 11) !== 'connected\n') {
+  //       console.log(data);
+  //       assert.equal(data.substring(data.length - 10), 'helys');
+  //       done();
+  //     }
   //   });
-  //   done();
+  //   client1.write('hello guys');
   // });
 
 
    
-    client2.on('data', data => {
-      if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
-        console.log('client2 data', data);
-        assert.equal(data.substring(data.length - 10), 'hello guys');
+//     client2.on('data', data => {
+//       if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
+//         console.log('client2 data', data);
+//         assert.equal(data.substring(data.length - 10), 'hello guys');
         
 
-      }
-    });
-    client3.on('data', data => {
-      if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
-        console.log('client3 data', data);
-        assert.equal(data.substring(data.length - 10), 'hello');
-        done();
-      }
-    });
-    client1.on('data', data => {
-      assert.equal(data.substring(data.indexOf(' ') + 1), 'has connected\n');
-    });
-    client1.write('hello guys');
-  });
+//       }
+//     });
+//     client3.on('data', data => {
+//       if (data.split(' ')[0] !== 'Use' && data.substring(data.length - 11) !== 'connected\n') {
+//         console.log('client3 data', data);
+//         assert.equal(data.substring(data.length - 10), 'hello');
+//         done();
+//       }
+//     });
+//     client1.on('data', data => {
+//       assert.equal(data.substring(data.indexOf(' ') + 1), 'has connected\n');
+//     });
+//     client1.write('hello guys');
+//   });
+// });
+
 });
 
 
+describe('Unit testing for a tcp chat client that tracks new connections, broadcasts messages, and allows name changes', () => {
 
+  const chatRoom = new ChatRoom();
 
-// describe('Unit testing for a tcp chat client that tracks new connections, broadcasts messages, and allows name changes', () => {
+  class MockClient {
+    write(message) {
+      this.received = message;
+    }
+  }
+  const client1 = new MockClient();
+  const client2 = new MockClient();
 
-//   const chatRoom = new ChatRoom();
+  it('should add clients', () => {
+    assert.equal(chatRoom.clients.length, 0);
+    chatRoom.add(client1);
+    assert.equal(chatRoom.clients.length, 1);
+    assert.equal(chatRoom.clients[0], client1);
+  });
 
-//   class MockClient {
-//     write(message) {
-//       this.received = message;
-//     }
-//   }
-//   const client1 = new MockClient();
-//   const client2 = new MockClient();
+  it('should broadcast messages to other clients', () => {
+    chatRoom.add(client2);
+    chatRoom.send(client2, 'hello people');
+    assert.equal(client1.received.substring(client1.received.indexOf(': ') + 2), 'hello people');
+  });
 
-//   it('should add clients', () => {
-//     assert.equal(chatRoom.clients.length, 0);
-//     chatRoom.add(client1);
-//     assert.equal(chatRoom.clients.length, 1);
-//     assert.equal(chatRoom.clients[0], client1);
-//   });
-
-//   it('should broadcast messages to other clients', () => {
-//     chatRoom.add(client2);
-//     chatRoom.send(client2, 'hello people');
-//     assert.equal(client1.received.substring(client1.received.indexOf(': ') + 2), 'hello people');
-//   });
-
-//   it('should accept a new name from input', () => {
-//     chatRoom.changeNick(client1, '/newName Roger the clown');
-//     assert.equal(client1.nick, 'Roger the clown');
-//   });
+  it('should accept a new name from input', () => {
+    chatRoom.changeNick(client1, '/newName Roger the clown');
+    assert.equal(client1.nick, 'Roger the clown');
+  });
 
 
 
-// });
+});

--- a/test/chatRoom-test.js
+++ b/test/chatRoom-test.js
@@ -3,10 +3,12 @@ const ChatRoom = require('../chatRoom');
 const server = require('../tcpChat');
 const net = require('net');
 
+
 describe('E2E test for a tcp chat client', () => {
   const port = 65000;
   let client1 = null;
   let client2 = null;
+  let client3 = null;
 
 
   before(done => {
@@ -29,12 +31,59 @@ describe('E2E test for a tcp chat client', () => {
       assert.equal(data.split('name\n')[0] + 'name\n', 'Use these commands:\n/newName <name> will change name to one of your choosing \n/newRandom will generate a random name\n');
       done();
     });
-    // client2.once('data', data => {
-    //   assert.equal(data.substring(data.indexOf(': ') + 2, 'has connected'));
-    // });
-    // makeClient(client2);
   });
 
+  it('Should display <client> has connected to all clients', (done) => {
+    client1.once('data', data => {
+      assert.equal(data.substring(data.indexOf(' ') + 1), 'has connected\n');
+      done();
+    });
+    client2 = net.connect({port: port}, err => {
+      if (err) done(err);
+      else {
+        client2.setEncoding('utf8');
+      }
+    });
+
+  });
+
+  it('Should display messages from one client to the others', done => {
+  //   client1.write('hello guys');
+
+  //   client2.on('data', data => {
+  //     console.log(data);
+  //   });
+  //   done();
+  // });
+
+    client3 = net.connect({port: port}), err => {
+      if (err) done(err);
+      else {
+        client3.setEncoding('utf8');
+
+      }
+    };
+   
+    client2.on('data', data => {
+      if (data.split(' ')[0] !== 'Use' && data.substring(data.length -9) !== 'connected') {
+        console.log('client2 data', data);
+        assert.equal(data.substring(data.length - 10), 'hello guys');
+        
+
+      }
+    });
+    client3.on('data', data => {
+      if (data.split(' ')[0] !== 'Use' && data.substring(data.length -9) !== 'connected') {
+        console.log('client3 data', data);
+        assert.equal(data.substring(data.length - 10), 'hello guys');
+        done();
+      }
+    });
+    client1.on('data', data => {
+      assert.equal(data.substring(data.indexOf(' ') + 1), 'has connected\n');
+    });
+    client1.write('hello guys');
+  });
 });
 
 


### PR DESCRIPTION
Tests work, HOWEVER:

In our 3rd "it block" (which tests if messages are being broadcast to everyone but sender) there's a possibility that the correct message is sent, thus triggering the non-sender client data event which then calls assert and done() -- in this instance, I don't believe event listener on the sender client gets a chance to run its check that it didn't receive it's own message (since done() has already been called).

We aren't clear on how to call done() only after all event listeners have had the chance to fire and assert().

UPDATE:: I think the issue above is fixed, based on the order in which we add the event listeners.